### PR TITLE
upgrade geojsonhint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "concat-stream": "~1.5.2",
-    "geojsonhint": "2.0.0-beta2",
+    "geojsonhint": "2.0.0",
     "github": "~3.1.1",
     "minimist": "1.2.0",
     "opener": "~1.4.2"


### PR DESCRIPTION
pulls in a fix for [wrong winding order detection](https://github.com/mapbox/geojsonhint/blob/master/CHANGELOG.md#200)